### PR TITLE
 Add k8s monitoring watchers

### DIFF
--- a/scripts/alerting/install_watchers.py
+++ b/scripts/alerting/install_watchers.py
@@ -47,6 +47,8 @@ base_url=args.elasticsearch_host+"/_watcher/watch/"
 headersList = {"Content-Type": "application/json"}
 
 for watcher in watchers:
+    if len(watcher.split(".disabled")) > 1:
+        continue
     # Create the watcher
 
     f = open('./watchers/'+watcher)

--- a/scripts/alerting/install_watchers.py
+++ b/scripts/alerting/install_watchers.py
@@ -1,0 +1,68 @@
+import requests
+import json
+import argparse
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+import subprocess
+import sys
+
+from sys import exit
+from os import listdir
+from os.path import isfile, join
+from requests.auth import HTTPBasicAuth
+
+# Create the parser
+my_parser = argparse.ArgumentParser(description='Install Elasticsearch watchers for k8s monitoring')
+
+# Add the arguments
+my_parser.add_argument('-elasticsearch-host',
+                       '-es',
+                       type=str,
+                       nargs="?",
+                       const="https://localhost:9200",
+                       default="https://localhost:9200",
+                       help='The url of Elasticsearch Watcher API')
+my_parser.add_argument('-username',
+                       '-u',
+                       type=str,
+                       nargs="?",
+                       const="elastic",
+                       default="elastic",
+                       help='The username to access the ES API')
+my_parser.add_argument('-password',
+                       '-p',
+                       type=str,
+                       nargs="?",
+                       const="changeme",
+                       default="changeme",
+                       help='The password to access the ES API')
+
+args = my_parser.parse_args()
+
+watchers_path = "./watchers"
+watchers = [f for f in listdir(watchers_path) if isfile(join(watchers_path, f))]
+print("Watchers to be installed: " + str(watchers))
+
+base_url=args.elasticsearch_host+"/_watcher/watch/"
+headersList = {"Content-Type": "application/json"}
+
+for watcher in watchers:
+    # Create the watcher
+
+    f = open('./watchers/'+watcher)
+    watcher_body = json.load(f)
+
+    watcher_name = watcher.split(".json")[0]
+    url = base_url+watcher_name+"?pretty"
+    res = requests.post(
+        url+"",
+        headers=headersList,
+        verify=False,
+        json=watcher_body,
+        auth = HTTPBasicAuth(args.username, args.password)
+    )
+    if res.status_code not in [200, 201]:
+        print("Status code is: " + str(res.status_code))
+        print("Error- Installing Watcher")
+        print(res.text)
+        exit(1)

--- a/scripts/alerting/watchers/apiserver-latency-watcher.json
+++ b/scripts/alerting/watchers/apiserver-latency-watcher.json
@@ -1,0 +1,96 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "search_type": "query_then_fetch",
+        "indices": [
+          "*"
+        ],
+        "rest_total_hits_as_int": true,
+        "body": {
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: apiserver AND NOT (kubernetes.apiserver.request.verb: WATCH or kubernetes.apiserver.request.verb: CONNECT)",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.apiserver.request.duration"
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "size": 0,
+          "runtime_mappings": {
+            "avg_duration": {
+              "type": "double",
+              "script": {
+                "source": "emit(doc['kubernetes.apiserver.request.duration.us.sum'].value / doc['kubernetes.apiserver.request.duration.us.count'].value / 1000 )"
+              }
+            }
+          },
+          "aggs": {
+            "avg_duration": {
+              "avg": {
+                "field": "avg_duration"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "condition": {
+    "script": {
+      "source": "return ctx.payload.aggregations.avg_duration.value > params.threshold",
+      "params": {
+        "threshold": 10
+      }
+    }
+  },
+  "actions": {
+    "my-logging-action": {
+      "logging": {
+        "level": "error",
+        "text": "The average request duration for k8s API Server is {{ctx.payload.aggregations.avg_duration}} ms. Threshold is 10 ms."
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "API Server Latency"
+  }
+}

--- a/scripts/alerting/watchers/controllermanager-latency-watcher.json
+++ b/scripts/alerting/watchers/controllermanager-latency-watcher.json
@@ -1,0 +1,93 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: controllermanager",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.controllermanager.client.request.duration"
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "size": 0,
+          "runtime_mappings": {
+            "avg_duration": {
+              "type": "double",
+              "script": {
+                "source": "emit(doc['kubernetes.controllermanager.client.request.duration.us.sum'].value / doc['kubernetes.controllermanager.client.request.duration.us.count'].value / 1000 )"
+              }
+            }
+          },
+          "aggs": {
+            "avg_duration": {
+              "avg": {
+                "field": "avg_duration"
+              }
+            }
+          }
+        },
+        "indices": [
+          "*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "script": {
+      "source": "return ctx.payload.aggregations.avg_duration.value > params.threshold",
+      "params": {
+        "threshold": 10
+      }
+    }
+  },
+  "actions": {
+    "my-logging-action": {
+      "logging": {
+        "text": "The average request duration for k8s Controller Manager is {{ctx.payload.aggregations.avg_duration}} ms. Threshold is 10."
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Controller Manager Request Latency"
+  }
+}

--- a/scripts/alerting/watchers/kubernetes-shipped-docs-watcher.json
+++ b/scripts/alerting/watchers/kubernetes-shipped-docs-watcher.json
@@ -1,0 +1,72 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "1m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-1m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "lte": 10
+      }
+    }
+  },
+  "actions": {
+    "my-logging-action": {
+      "logging": {
+        "text": "{{ctx.payload.hits.total}} documents were shipped in your Kubernetes indexes during the last minute. Threshold is at least 10."
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Kubernetes Shipped Docs"
+  }
+}

--- a/scripts/alerting/watchers/node-cpu-utilisation-watcher.json
+++ b/scripts/alerting/watchers/node-cpu-utilisation-watcher.json
@@ -1,0 +1,116 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND (metricset.name:node OR metricset.name: state_node) ",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "size": "10000",
+                "order": {
+                  "_key": "asc"
+                }
+              },
+              "aggs": {
+                "nodeUsage": {
+                  "max": {
+                    "field": "kubernetes.node.cpu.usage.nanocores"
+                  }
+                },
+                "nodeCap": {
+                  "max": {
+                    "field": "kubernetes.node.cpu.capacity.cores"
+                  }
+                },
+                "nodeCPUUsagePCT": {
+                  "bucket_script": {
+                    "buckets_path": {
+                      "nodeUsage": "nodeUsage",
+                      "nodeCap": "nodeCap"
+                    },
+                    "script": {
+                      "source": "( params.nodeUsage / 1000000000 ) / params.nodeCap",
+                      "lang": "painless",
+                      "params": {
+                        "_interval": 10000
+                      }
+                    },
+                    "gap_policy": "skip"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "array_compare": {
+      "ctx.payload.aggregations.nodes.buckets": {
+        "path": "nodeCPUUsagePCT.value",
+        "gte": {
+          "value": 80
+        }
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found with high CPU usage: {{ctx.payload.key}} -> {{ctx.payload.nodeCPUUsagePCT.value}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node CPU Usage"
+  }
+}

--- a/scripts/alerting/watchers/node-disk-pressure-watcher.json
+++ b/scripts/alerting/watchers/node-disk-pressure-watcher.json
@@ -1,0 +1,95 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_node",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.node.status.disk_pressure"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.node.status.disk_pressure: true",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.state_node-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found on disk pressure: {{ctx.payload.key}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Disk Pressure"
+  }
+}

--- a/scripts/alerting/watchers/node-memory-pressure-watcher.json
+++ b/scripts/alerting/watchers/node-memory-pressure-watcher.json
@@ -1,0 +1,95 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_node",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.node.status.memory_pressure"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.node.status.memory_pressure: true",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.state_node-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found on memory pressure: {{ctx.payload.key}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Memory Pressure"
+  }
+}

--- a/scripts/alerting/watchers/node-memory-utilisation-watcher.json
+++ b/scripts/alerting/watchers/node-memory-utilisation-watcher.json
@@ -1,0 +1,116 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND (metricset.name:node OR metricset.name: state_node) ",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "size": "10000",
+                "order": {
+                  "_key": "asc"
+                }
+              },
+              "aggs": {
+                "nodeUsage": {
+                  "max": {
+                    "field": "kubernetes.node.memory.usage.bytes"
+                  }
+                },
+                "nodeCap": {
+                  "max": {
+                    "field": "kubernetes.node.memory.capacity.bytes"
+                  }
+                },
+                "nodeMemoryUsagePCT": {
+                  "bucket_script": {
+                    "buckets_path": {
+                      "nodeUsage": "nodeUsage",
+                      "nodeCap": "nodeCap"
+                    },
+                    "script": {
+                      "source": "( params.nodeUsage ) / params.nodeCap",
+                      "lang": "painless",
+                      "params": {
+                        "_interval": 10000
+                      }
+                    },
+                    "gap_policy": "skip"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "array_compare": {
+      "ctx.payload.aggregations.nodes.buckets": {
+        "path": "nodeMemoryUsagePCT.value",
+        "gte": {
+          "value": 80
+        }
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found with high memory usage: {{ctx.payload.key}} -> {{ctx.payload.nodeMemoryUsagePCT.value}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Memory Usage"
+  }
+}

--- a/scripts/alerting/watchers/node-not-ready-watcher.json
+++ b/scripts/alerting/watchers/node-not-ready-watcher.json
@@ -1,0 +1,95 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_node",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.node.status.ready"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.node.status.ready: false",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.state_node-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found not ready: {{ctx.payload.key}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Not Ready"
+  }
+}

--- a/scripts/alerting/watchers/node-out-of-disk-watcher.json
+++ b/scripts/alerting/watchers/node-out-of-disk-watcher.json
@@ -1,0 +1,95 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_node",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.node.status.out_of_disk"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.node.status.out_of_disk: true",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.state_node-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found out of disk: {{ctx.payload.key}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Out Of Disk"
+  }
+}

--- a/scripts/alerting/watchers/node-pid-pressure-watcher.json
+++ b/scripts/alerting/watchers/node-pid-pressure-watcher.json
@@ -1,0 +1,95 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_node",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.node.status.pid_pressure"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.node.status.pid_pressure: true",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.state_node-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found on pid pressure: {{ctx.payload.key}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Pid Pressure"
+  }
+}

--- a/scripts/alerting/watchers/node-unschedulable-watcher.json
+++ b/scripts/alerting/watchers/node-unschedulable-watcher.json
@@ -1,0 +1,95 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_node",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.node.status.unschedulable"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.node.status.unschedulable: true",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "nodes": {
+              "terms": {
+                "field": "kubernetes.node.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.state_node-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.nodes.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes node found unschedulable: {{ctx.payload.key}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Node Unschedulable"
+  }
+}

--- a/scripts/alerting/watchers/pod-rx-error-rate-watcher.json
+++ b/scripts/alerting/watchers/pod-rx-error-rate-watcher.json
@@ -1,0 +1,110 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND (metricset.name:pod) ",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "rx_error_rates": {
+              "terms": {
+                "field": "kubernetes.pod.name",
+                "size": "10000",
+                "order": {
+                  "_key": "asc"
+                }
+              },
+              "aggs": {
+                "by_minute": {
+                  "date_histogram": {
+                    "field": "@timestamp",
+                    "calendar_interval": "minute"
+                  },
+                  "aggs": {
+                    "my_rate": {
+                      "rate": {
+                        "field": "kubernetes.pod.network.rx.errors",
+                        "unit": "minute"
+                      }
+                    }
+                  }
+                },
+                "avg_minute_rate": {
+                  "avg_bucket": {
+                    "buckets_path": "by_minute>my_rate",
+                    "gap_policy": "skip"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.pod-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "array_compare": {
+      "ctx.payload.aggregations.rx_error_rates.buckets": {
+        "path": "avg_minute_rate.value",
+        "gt": {
+          "value": 1
+        }
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.rx_error_rates.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes Pod found with high rx error rate: {{ctx.payload.key}} -> {{ctx.payload.avg_minute_rate.value}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Pod RX Error Rate"
+  }
+}

--- a/scripts/alerting/watchers/pod-terminated-error-watcher.json
+++ b/scripts/alerting/watchers/pod-terminated-error-watcher.json
@@ -1,0 +1,98 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_container",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.container.status.last_terminated_reason"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.container.status.last_terminated_reason: Error",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "pods": {
+              "terms": {
+                "field": "kubernetes.pod.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "array_compare": {
+      "ctx.payload.aggregations.pods.buckets": {
+        "path": "doc_count",
+        "gte": {
+          "value": 1
+        }
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.pods.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Pod {{ctx.payload.key}} was terminated with status Error"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Pod Terminated Error"
+  }
+}

--- a/scripts/alerting/watchers/pod-terminated-oomkilled-watcher.json
+++ b/scripts/alerting/watchers/pod-terminated-oomkilled-watcher.json
@@ -1,0 +1,98 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND metricset.name: state_container",
+                          "analyze_wildcard": true
+                        }
+                      },
+                      {
+                        "exists": {
+                          "field": "kubernetes.container.status.last_terminated_reason"
+                        }
+                      },
+                      {
+                        "query_string": {
+                          "query": "kubernetes.container.status.last_terminated_reason: OOMKilled",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "pods": {
+              "terms": {
+                "field": "kubernetes.pod.name",
+                "order": {
+                  "_key": "asc"
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "array_compare": {
+      "ctx.payload.aggregations.pods.buckets": {
+        "path": "doc_count",
+        "gte": {
+          "value": 1
+        }
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.pods.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Pod {{ctx.payload.key}} was terminated with status OOMKilled"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Pod Terminated OOMKilled"
+  }
+}

--- a/scripts/alerting/watchers/pod-tx-error-rate-watcher.json
+++ b/scripts/alerting/watchers/pod-tx-error-rate-watcher.json
@@ -1,0 +1,110 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "10m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "now-10m",
+                      "lte": "now",
+                      "format": "strict_date_optional_time"
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "must": [
+                      {
+                        "query_string": {
+                          "query": "event.module:kubernetes AND (metricset.name:pod) ",
+                          "analyze_wildcard": true
+                        }
+                      }
+                    ],
+                    "filter": [],
+                    "should": [],
+                    "must_not": []
+                  }
+                }
+              ],
+              "filter": [],
+              "should": [],
+              "must_not": []
+            }
+          },
+          "aggs": {
+            "rx_error_rates": {
+              "terms": {
+                "field": "kubernetes.pod.name",
+                "size": "10000",
+                "order": {
+                  "_key": "asc"
+                }
+              },
+              "aggs": {
+                "by_minute": {
+                  "date_histogram": {
+                    "field": "@timestamp",
+                    "calendar_interval": "minute"
+                  },
+                  "aggs": {
+                    "my_rate": {
+                      "rate": {
+                        "field": "kubernetes.pod.network.rx.errors",
+                        "unit": "minute"
+                      }
+                    }
+                  }
+                },
+                "avg_minute_rate": {
+                  "avg_bucket": {
+                    "buckets_path": "by_minute>my_rate",
+                    "gap_policy": "skip"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "indices": [
+          "metrics-kubernetes.pod-default"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "array_compare": {
+      "ctx.payload.aggregations.rx_error_rates.buckets": {
+        "path": "avg_minute_rate.value",
+        "gt": {
+          "value": 1
+        }
+      }
+    }
+  },
+  "actions": {
+    "log_hits": {
+      "foreach": "ctx.payload.aggregations.rx_error_rates.buckets",
+      "max_iterations": 500,
+      "logging": {
+        "text": "Kubernetes Pod found with high rx error rate: {{ctx.payload.key}} -> {{ctx.payload.avg_minute_rate.value}}"
+      }
+    }
+  },
+  "metadata": {
+    "xpack": {
+      "type": "json"
+    },
+    "name": "Pod RX Error Rate"
+  }
+}


### PR DESCRIPTION
This PR adds the k8s watchers created for https://github.com/elastic/integrations/issues/4997 along with an installer script. 
These can be used for either testing or demos.